### PR TITLE
Add esp8266 support with default configuration.

### DIFF
--- a/ABBAurora.cpp
+++ b/ABBAurora.cpp
@@ -19,7 +19,15 @@ void ABBAurora::setup(HardwareSerial &hardwareSerial, byte RXGpioPin, byte TXGpi
     digitalWrite(TXPinControl, LOW);
 
     serial = &hardwareSerial;
+#if defined(USE_ESP32)
     serial->begin(19200, SERIAL_8N1, RXGpioPin, TXGpioPin, false, 500);
+#elif defined(USE_ESP8266)
+    serial->begin(19200, SERIAL_8N1, SERIAL_FULL);
+    if (RXGpioPin == 13 && TXGpioPin == 15) {
+        // Use alternate pins on Serial
+        serial->swap();
+    }
+#endif
 }
 
 void ABBAurora::clearData(byte *data, byte len)


### PR DESCRIPTION
esp8266 must use Serial on pins (1, 3) or (15, 13). Use sane defaults when building for esp8266.